### PR TITLE
Refactor Telegram client into an ergonomic bot framework.

### DIFF
--- a/cmd/savvy/report.go
+++ b/cmd/savvy/report.go
@@ -251,14 +251,14 @@ func hourNumbersForDay(day time.Time, count int) []int {
 func postToTelegram(report, token string, chatID chatid.ChatID, channelName string) (string, error) {
 	slog.Info("sending message", slog.String("chat_id", chatID.String()), slog.String("message", report))
 
-	bot := telegram.NewClient(token)
+	bot := telegram.NewBot(token)
 
 	message, err := bot.SendMessage(chatID, report, option.ParseModeHTML)
 	if err != nil {
 		return "", fmt.Errorf("send message: %w", err)
 	}
 
-	messageID := int64(message.ID)
+	messageID := message.ID
 	idLogger := slog.With(slog.Int64("message_id", messageID))
 
 	idLogger.Info("message sent")

--- a/cmd/savvy/serve.go
+++ b/cmd/savvy/serve.go
@@ -10,7 +10,6 @@ import (
 	"github.com/heyajulia/savvy/internal"
 	"github.com/heyajulia/savvy/internal/config"
 	"github.com/heyajulia/savvy/internal/telegram"
-	"github.com/heyajulia/savvy/internal/telegram/chatid"
 	"github.com/heyajulia/savvy/internal/telegram/option"
 	"github.com/urfave/cli/v3"
 )
@@ -37,6 +36,36 @@ func runServe(ctx context.Context, c *cli.Command) error {
 	token := cfg.Telegram.Token
 	channelName := cfg.Telegram.ChannelName
 	blueskyIdentifier := cfg.Bluesky.Identifier
+
+	bot := telegram.NewBot(token)
+
+	bot.OnCommand("/start", func(ctx *telegram.Context) error {
+		slog.Info("received command", slog.String("command", "/start"))
+		return ctx.Reply(
+			"Hallo! In privé-chats kan ik niet zo veel. Mijn kanaal @energieprijzen is veel interessanter.",
+			option.Keyboard(telegram.KeyboardStart(channelName, blueskyIdentifier)),
+		)
+	})
+
+	bot.OnCommand("/privacy", func(ctx *telegram.Context) error {
+		slog.Info("received command", slog.String("command", "/privacy"))
+		return handlePrivacy(ctx)
+	})
+
+	bot.OnCallback("privacy", func(ctx *telegram.Context) error {
+		slog.Info("received callback query", slog.String("data", "privacy"))
+		return handlePrivacy(ctx)
+	})
+
+	bot.OnCallback("got_it", func(ctx *telegram.Context) error {
+		slog.Info("received callback query", slog.String("data", "got_it"))
+		return ctx.DeleteMessage(ctx.Update().CallbackQuery.Message.ID)
+	})
+
+	bot.OnUnknown(func(ctx *telegram.Context) error {
+		return ctx.Reply("Sorry, ik begrijp je niet. Probeer /start of /privacy.")
+	})
+
 	lastProcessedUpdateID := int64(0)
 
 	for {
@@ -45,144 +74,26 @@ func runServe(ctx context.Context, c *cli.Command) error {
 			slog.Info("shutting down")
 			return nil
 		default:
-			if err := processUpdates(token, channelName, blueskyIdentifier, &lastProcessedUpdateID); err != nil {
+			id, err := bot.ProcessUpdates(lastProcessedUpdateID + 1)
+			if err != nil {
 				slog.Error("could not process updates", slog.Any("err", err))
+			}
+			if id > lastProcessedUpdateID {
+				lastProcessedUpdateID = id
 			}
 		}
 	}
 }
 
-func unknownCommand(token string, userID chatid.ChatID) error {
-	bot := telegram.NewClient(token)
-
-	_, err := bot.SendMessage(userID, "Sorry, ik begrijp je niet. Probeer /start of /privacy.")
-
-	return err
-}
-
-func privacy(token string, userID chatid.ChatID) error {
+func handlePrivacy(ctx *telegram.Context) error {
 	var sb strings.Builder
 
-	if err := templates.ExecuteTemplate(&sb, "privacy.tmpl", userID.String()); err != nil {
+	if err := templates.ExecuteTemplate(&sb, "privacy.tmpl", ctx.UserID()); err != nil {
 		return fmt.Errorf("render privacy policy: %w", err)
 	}
 
-	bot := telegram.NewClient(token)
-
-	_, err := bot.SendMessage(
-		userID,
+	return ctx.ReplyMarkdown(
 		sb.String(),
-		option.ParseModeMarkdown,
 		option.Keyboard(telegram.KeyboardPrivacy()),
 	)
-
-	return err
-}
-
-func handleCommand(token, channelName, blueskyIdentifier string, userID chatid.ChatID, text string) error {
-	switch text {
-	case "/start":
-		slog.Info("received command", slog.String("command", text))
-
-		bot := telegram.NewClient(token)
-
-		if _, err := bot.SendMessage(
-			userID,
-			"Hallo! In privé-chats kan ik niet zo veel. Mijn kanaal @energieprijzen is veel interessanter.",
-			option.Keyboard(telegram.KeyboardStart(channelName, blueskyIdentifier)),
-		); err != nil {
-			return err
-		}
-	case "/privacy":
-		slog.Info("received command", slog.String("command", text))
-
-		if err := privacy(token, userID); err != nil {
-			return err
-		}
-	default:
-		slog.Info("received unknown command")
-
-		if err := unknownCommand(token, userID); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func handleCallbackQuery(token string, userID chatid.ChatID, messageID int64, data string) error {
-	switch data {
-	case "privacy":
-		slog.Info("received callback query", slog.String("data", data))
-
-		if err := privacy(token, userID); err != nil {
-			return err
-		}
-	case "got_it":
-		slog.Info("received callback query", slog.String("data", data))
-
-		bot := telegram.NewClient(token)
-
-		if err := bot.DeleteMessage(userID, messageID); err != nil {
-			return err
-		}
-	default:
-		slog.Info("received unknown callback query")
-
-		if err := unknownCommand(token, userID); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func processUpdates(token, channelName, blueskyIdentifier string, lastProcessedUpdateID *int64) error {
-	bot := telegram.NewClient(token)
-
-	updates, err := bot.GetUpdates(*lastProcessedUpdateID + 1)
-	if err != nil {
-		return err
-	}
-
-	for _, update := range updates {
-		*lastProcessedUpdateID = int64(update.ID)
-
-		userID := update.UserID()
-
-		switch {
-		case update.IsMessage():
-			text := update.Message.Text
-
-			if text == nil {
-				slog.Info("message doesn't contain text")
-
-				if err := unknownCommand(token, userID); err != nil {
-					return err
-				}
-
-				continue
-			}
-
-			if err := handleCommand(token, channelName, blueskyIdentifier, userID, *text); err != nil {
-				return err
-			}
-		case update.IsCallbackQuery():
-			callbackQuery := *update.CallbackQuery
-			messageID := int64(callbackQuery.Message.ID)
-			data := callbackQuery.Data
-
-			if err := bot.AnswerCallbackQuery(callbackQuery.ID); err != nil {
-				return err
-			}
-
-			if err := handleCallbackQuery(token, userID, messageID, data); err != nil {
-				return err
-			}
-		default:
-			panic("unreachable")
-		}
-	}
-
-	return nil
 }

--- a/internal/telegram/bot.go
+++ b/internal/telegram/bot.go
@@ -1,0 +1,326 @@
+package telegram
+
+import (
+	"fmt"
+	"log/slog"
+	"net/url"
+	"strconv"
+
+	"github.com/heyajulia/savvy/internal/telegram/chatid"
+	"github.com/heyajulia/savvy/internal/telegram/option"
+)
+
+// Update represents a single Telegram update.
+type Update struct {
+	ID            int64
+	Message       *Message
+	CallbackQuery *CallbackQuery
+}
+
+func (u Update) IsMessage() bool {
+	return u.Message != nil
+}
+
+func (u Update) IsCallbackQuery() bool {
+	return u.CallbackQuery != nil
+}
+
+func (u Update) UserID() chatid.ChatID {
+	if u.IsMessage() {
+		return u.Message.From.ID
+	}
+	return u.CallbackQuery.From.ID
+}
+
+// Message represents a Telegram message.
+type Message struct {
+	ID   int64
+	From User
+	Text *string
+}
+
+// User represents a Telegram user.
+type User struct {
+	ID chatid.ChatID
+}
+
+// CallbackQuery represents an incoming callback query.
+type CallbackQuery struct {
+	ID      string
+	From    User
+	Message Message
+	Data    string
+}
+
+// Context is passed to every handler and provides helpers for replying.
+type Context struct {
+	bot    *Bot
+	update Update
+}
+
+// Update returns the raw update.
+func (c *Context) Update() Update {
+	return c.update
+}
+
+// UserID returns the chat ID of the user who triggered this update.
+func (c *Context) UserID() chatid.ChatID {
+	return c.update.UserID()
+}
+
+// Reply sends a text message to the same chat.
+func (c *Context) Reply(text string, options ...option.Option) error {
+	chatID := c.update.UserID()
+	_, err := c.bot.doSendMessage(chatID, text, options...)
+	return err
+}
+
+// ReplyHTML sends an HTML-formatted message to the same chat.
+func (c *Context) ReplyHTML(text string, options ...option.Option) error {
+	return c.Reply(text, append([]option.Option{option.ParseModeHTML}, options...)...)
+}
+
+// ReplyMarkdown sends a Markdown-formatted message to the same chat.
+func (c *Context) ReplyMarkdown(text string, options ...option.Option) error {
+	return c.Reply(text, append([]option.Option{option.ParseModeMarkdown}, options...)...)
+}
+
+// DeleteMessage deletes a message in the chat.
+func (c *Context) DeleteMessage(messageID int64) error {
+	return c.bot.deleteMessage(c.update.UserID(), messageID)
+}
+
+// AnswerCallbackQuery answers a callback query.
+func (c *Context) AnswerCallbackQuery() error {
+	if c.update.CallbackQuery == nil {
+		return fmt.Errorf("telegram: not a callback query")
+	}
+	return c.bot.answerCallbackQuery(c.update.CallbackQuery.ID)
+}
+
+// SetMessageReaction sets a reaction on a message.
+func (c *Context) SetMessageReaction(messageID int64) error {
+	return c.bot.setMessageReaction(c.update.UserID(), messageID)
+}
+
+// Handler is a function that processes an update.
+type Handler func(ctx *Context) error
+
+// commandRoute maps command strings (e.g. "/start") to handlers.
+type commandRoute struct {
+	command string
+	handler Handler
+}
+
+// callbackRoute maps callback data strings to handlers.
+type callbackRoute struct {
+	data    string
+	handler Handler
+}
+
+// Bot is the high-level Telegram bot.
+type Bot struct {
+	token          string
+	commands       []commandRoute
+	callbacks      []callbackRoute
+	unknownHandler Handler
+}
+
+// NewBot creates a new Bot with the given token.
+func NewBot(token string) *Bot {
+	return &Bot{
+		token: token,
+	}
+}
+
+// OnCommand registers a handler for a specific command (e.g. "/start").
+func (b *Bot) OnCommand(command string, handler Handler) {
+	b.commands = append(b.commands, commandRoute{command, handler})
+}
+
+// OnCallback registers a handler for a specific callback query data value.
+func (b *Bot) OnCallback(data string, handler Handler) {
+	b.callbacks = append(b.callbacks, callbackRoute{data, handler})
+}
+
+// OnUnknown registers a fallback handler for unrecognized commands and callbacks.
+// If not set, unknown commands and callbacks are silently ignored.
+func (b *Bot) OnUnknown(handler Handler) {
+	b.unknownHandler = handler
+}
+
+// ProcessUpdates fetches and processes all pending updates, starting from offset.
+// It returns the last processed update ID so callers can resume.
+func (b *Bot) ProcessUpdates(offset int64) (int64, error) {
+	rawUpdates, err := b.getUpdates(offset)
+	if err != nil {
+		return offset, err
+	}
+
+	for _, raw := range rawUpdates {
+		update := Update{
+			ID: raw.ID,
+		}
+
+		if raw.Message != nil {
+			update.Message = &Message{
+				ID:   raw.Message.ID,
+				From: User{ID: raw.Message.From.ID},
+				Text: raw.Message.Text,
+			}
+		}
+
+		if raw.CallbackQuery != nil {
+			update.CallbackQuery = &CallbackQuery{
+				ID: raw.CallbackQuery.ID,
+				From: User{
+					ID: raw.CallbackQuery.From.ID,
+				},
+				Message: Message{
+					ID: raw.CallbackQuery.Message.ID,
+				},
+				Data: raw.CallbackQuery.Data,
+			}
+		}
+
+		ctx := &Context{bot: b, update: update}
+
+		if err := b.dispatch(ctx); err != nil {
+			slog.Error("handler error", slog.Any("err", err))
+		}
+
+		offset = update.ID
+	}
+
+	return offset, nil
+}
+
+func (b *Bot) dispatch(ctx *Context) error {
+	switch {
+	case ctx.update.IsMessage():
+		return b.dispatchMessage(ctx)
+	case ctx.update.IsCallbackQuery():
+		return b.dispatchCallback(ctx)
+	default:
+		return nil
+	}
+}
+
+func (b *Bot) dispatchMessage(ctx *Context) error {
+	text := ctx.update.Message.Text
+	if text == nil {
+		return nil
+	}
+
+	for _, route := range b.commands {
+		if *text == route.command {
+			return route.handler(ctx)
+		}
+	}
+
+	if b.unknownHandler != nil {
+		return b.unknownHandler(ctx)
+	}
+
+	return nil
+}
+
+func (b *Bot) dispatchCallback(ctx *Context) error {
+	data := ctx.update.CallbackQuery.Data
+
+	for _, route := range b.callbacks {
+		if data == route.data {
+			return route.handler(ctx)
+		}
+	}
+
+	if b.unknownHandler != nil {
+		return b.unknownHandler(ctx)
+	}
+
+	return nil
+}
+
+// SendMessage sends a message to the given chat. It is a public method for
+// non-interactive use (e.g. posting reports). For replying inside handlers,
+// prefer Context.Reply.
+func (b *Bot) SendMessage(chatID chatid.ChatID, text string, options ...option.Option) (*Message, error) {
+	msg, err := b.doSendMessage(chatID, text, options...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Message{
+		ID:   msg.ID,
+		From: User{ID: msg.From.ID},
+		Text: msg.Text,
+	}, nil
+}
+
+// doSendMessage is the internal transport-level send used by both SendMessage
+// and Context.Reply.
+func (b *Bot) doSendMessage(chatID chatid.ChatID, text string, options ...option.Option) (*rawMessage, error) {
+	parameters := url.Values{
+		"chat_id": {chatID.String()},
+		"text":    {text},
+	}
+
+	for _, o := range options {
+		o(parameters)
+	}
+
+	msg, err := sendRequest[rawMessage](b.token, "sendMessage", parameters)
+	if err != nil {
+		return nil, fmt.Errorf("telegram: sendMessage: %w", err)
+	}
+
+	return msg, nil
+}
+
+// SetMessageReaction sets a reaction on a message in the given chat.
+func (b *Bot) SetMessageReaction(chatID chatid.ChatID, messageID int64) error {
+	return b.setMessageReaction(chatID, messageID)
+}
+
+func (b *Bot) deleteMessage(chatID chatid.ChatID, messageID int64) error {
+	return b.fireOff("deleteMessage", url.Values{
+		"chat_id":    {chatID.String()},
+		"message_id": {strconv.FormatInt(messageID, 10)},
+	})
+}
+
+func (b *Bot) answerCallbackQuery(id string) error {
+	return b.fireOff("answerCallbackQuery", url.Values{
+		"callback_query_id": {id},
+	})
+}
+
+func (b *Bot) setMessageReaction(chatID chatid.ChatID, messageID int64) error {
+	return b.fireOff("setMessageReaction", url.Values{
+		"chat_id":    {chatID.String()},
+		"message_id": {strconv.FormatInt(messageID, 10)},
+		"is_big":     {"true"},
+		"reaction":   {reaction},
+	})
+}
+
+func (b *Bot) getUpdates(offset int64) ([]rawUpdate, error) {
+	updates, err := sendRequest[[]rawUpdate](b.token, "getUpdates", url.Values{
+		"offset":          {strconv.FormatInt(offset, 10)},
+		"timeout":         {"60"},
+		"allowed_updates": {allowedUpdates},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("telegram: getUpdates: %w", err)
+	}
+
+	return *updates, nil
+}
+
+func (b *Bot) fireOff(method string, parameters url.Values) error {
+	if _, err := sendRequest[any](b.token, method, parameters); err != nil {
+		return fmt.Errorf("telegram: %s: %w", method, err)
+	}
+
+	return nil
+}

--- a/internal/telegram/telegram.go
+++ b/internal/telegram/telegram.go
@@ -5,10 +5,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"strconv"
 
 	"github.com/heyajulia/savvy/internal/telegram/chatid"
-	"github.com/heyajulia/savvy/internal/telegram/option"
 )
 
 var (
@@ -16,112 +14,28 @@ var (
 	allowedUpdates = marshal([]string{"message", "callback_query"})
 )
 
-type update struct {
-	ID            float64        `json:"update_id"`
-	Message       *message       `json:"message"`
-	CallbackQuery *callbackQuery `json:"callback_query"`
+// rawUpdate is the wire-format representation of a Telegram update.
+type rawUpdate struct {
+	ID            int64           `json:"update_id"`
+	Message       *rawMessage     `json:"message"`
+	CallbackQuery *rawCallbackQuery `json:"callback_query"`
 }
 
-func (u update) IsMessage() bool {
-	return u.Message != nil
-}
-
-func (u update) IsCallbackQuery() bool {
-	return u.CallbackQuery != nil
-}
-
-func (u update) UserID() chatid.ChatID {
-	if u.IsMessage() {
-		return u.Message.From.ID
-	}
-
-	return u.CallbackQuery.From.ID
-}
-
-type user struct {
+type rawUser struct {
 	ID chatid.ChatID `json:"id"`
 }
 
-type message struct {
-	ID   float64 `json:"message_id"`
-	From user    `json:"from"`
-	Text *string `json:"text"`
+type rawMessage struct {
+	ID   int64    `json:"message_id"`
+	From rawUser  `json:"from"`
+	Text *string  `json:"text"`
 }
 
-type callbackQuery struct {
-	ID      string  `json:"id"`
-	From    user    `json:"from"`
-	Message message `json:"message"`
-	Data    string  `json:"data"`
-}
-
-type client struct {
-	token string
-}
-
-func NewClient(token string) *client {
-	return &client{token}
-}
-
-func (c *client) GetUpdates(offset int64) ([]update, error) {
-	updates, err := sendRequest[[]update](c.token, "getUpdates", url.Values{
-		"offset":          {strconv.FormatInt(offset, 10)},
-		"timeout":         {"60"},
-		"allowed_updates": {allowedUpdates},
-	})
-	if err != nil {
-		return nil, fmt.Errorf("telegram: getUpdates: %w", err)
-	}
-
-	return *updates, nil
-}
-
-func (c *client) DeleteMessage(chatID chatid.ChatID, messageID int64) error {
-	return c.fireOff("deleteMessage", url.Values{
-		"chat_id":    {chatID.String()},
-		"message_id": {strconv.FormatInt(messageID, 10)},
-	})
-}
-
-func (c *client) AnswerCallbackQuery(id string) error {
-	return c.fireOff("answerCallbackQuery", url.Values{
-		"callback_query_id": {id},
-	})
-}
-
-func (c *client) SetMessageReaction(chatID chatid.ChatID, messageID int64) error {
-	return c.fireOff("setMessageReaction", url.Values{
-		"chat_id":    {chatID.String()},
-		"message_id": {strconv.FormatInt(messageID, 10)},
-		"is_big":     {"true"},
-		"reaction":   {reaction},
-	})
-}
-
-func (c *client) SendMessage(chatID chatid.ChatID, text string, options ...option.Option) (*message, error) {
-	parameters := url.Values{
-		"chat_id": {chatID.String()},
-		"text":    {text},
-	}
-
-	for _, o := range options {
-		o(parameters)
-	}
-
-	message, err := sendRequest[message](c.token, "sendMessage", parameters)
-	if err != nil {
-		return nil, fmt.Errorf("telegram: sendMessage: %w", err)
-	}
-
-	return message, nil
-}
-
-func (c *client) fireOff(method string, parameters url.Values) error {
-	if _, err := sendRequest[any](c.token, method, parameters); err != nil {
-		return fmt.Errorf("telegram: %s: %w", method, err)
-	}
-
-	return nil
+type rawCallbackQuery struct {
+	ID      string      `json:"id"`
+	From    rawUser     `json:"from"`
+	Message rawMessage  `json:"message"`
+	Data    string      `json:"data"`
 }
 
 func sendRequest[T any](token, method string, parameters url.Values) (*T, error) {


### PR DESCRIPTION
Replace the thin HTTP wrapper (NewClient) with a declarative Bot that supports command and callback registration (OnCommand, OnCallback, OnUnknown) and a Context object with high-level reply helpers (Reply, ReplyHTML, ReplyMarkdown, DeleteMessage, etc.).

The low-level transport (sendRequest, raw wire types) stays in telegram.go as unexported internals. The serve command is simplified to handler registration instead of a manual update loop with switch statements. The report command uses Bot.SendMessage for one-shot sends.

Co-authored-by: Owl Alpha